### PR TITLE
View panels

### DIFF
--- a/lib/plot/D3LinePlot.js
+++ b/lib/plot/D3LinePlot.js
@@ -358,8 +358,6 @@ class D3LinePlot {
   plot(lineData) {
     Preconditions.checkArgumentInstanceOf(lineData, D3LineData);
 
-    this.view.viewFooter.plotBtnEl.click();
-
     lineData = this._dataEnter(lineData);
 
     let xScale = this._getCurrentXScale(lineData.subView);

--- a/lib/view/D3BaseView.js
+++ b/lib/view/D3BaseView.js
@@ -460,10 +460,10 @@ class D3BaseView {
         .attr('class', 'panel-body panel-outer');
     
     let dataTableD3 = viewBodyD3.append('div')
-        .attr('class', 'data-table panel-table hidden');
+        .attr('class', 'data-table panel-table hide-panel');
 
     let metadataTableD3 = viewBodyD3.append('div')
-        .attr('class', 'metadata-table panel-table hidden');
+        .attr('class', 'metadata-table panel-table hide-panel');
 
     let els = {
       viewEl: elD3.node(),
@@ -548,20 +548,20 @@ class D3BaseView {
         `Selected view [${selectedView}] is not supported`);
 
     this.dataTableEl.classList.toggle(
-        'hidden',
+        'hide-panel',
         selectedView != 'data');
 
     this.metadataTableEl.classList.toggle(
-        'hidden',
+        'hide-panel',
         selectedView != 'metadata');
 
     this.upperSubView.subViewBodyEl.classList.toggle(
-        'hidden',
+        'hide-panel',
         selectedView != 'plot');
 
     if (this.addLowerSubView) {
       this.lowerSubView.subViewBodyEl.classList.toggle(
-          'hidden',
+          'hide-panel',
           selectedView != 'plot');
     }
   }
@@ -583,7 +583,7 @@ class D3BaseView {
 
     let nViews = d3.selectAll('.D3View') 
         .filter((d, i, els) => {
-          return !d3.select(els[i]).classed('hidden');
+          return !d3.select(els[i]).classed('hide-panel');
         }).size();
     
     switch(this._currentViewSize) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nshmp/nshmp-d3",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nshmp/nshmp-d3",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "",
   "main": "index.js",
   "types": "./lib/index.d.ts",

--- a/scss/nshmp-d3.scss
+++ b/scss/nshmp-d3.scss
@@ -34,6 +34,11 @@
   border-top: 1px solid #ddd;
   position: relative;
 }
+
+.D3View .hide-panel {
+  visibility: hidden;
+  position: absolute;
+}
               
 /* Plot panel footer */
 .D3View .panel .panel-footer {


### PR DESCRIPTION
* Updated how the different panels (plot, data, metadata) are hidden
* Previously they were hidden with `display: none`, however this caused an error if a plot was added and the plot was not being shown
* Updated to `visibility: hidden` and `position: absolute`